### PR TITLE
Fix literal strings newline chomping

### DIFF
--- a/scripts/gakumasu_diff_to_json.py
+++ b/scripts/gakumasu_diff_to_json.py
@@ -536,6 +536,7 @@ def convert_yaml_types(folder_path="./gakumasu-diff/orig"):
                         content = f.read()
                     # content = content.replace('\t', '    ')  # 替换制表符
                     content = content.replace(": \t", ": \"\t\"")  # 替换制表符
+                    content = content.replace("|\n", "|+\n") # Fix literal strings newline chomping
 
                     # 解析 YAML 内容
                     # data = yaml.safe_load(content)


### PR DESCRIPTION
The yaml files contain many fields of the form
```yaml
text: |

other_stuff: blah
```
The text field is interpreted as an empty string `""`, but it should be interpreted as a newline `"\n"`.
This pull request replaces all literal strings using `|` with literal strings using `|+` instead, which makes the above text field a newline instead.